### PR TITLE
2fa fixes

### DIFF
--- a/backend/api/views/auth_views.py
+++ b/backend/api/views/auth_views.py
@@ -60,9 +60,9 @@ class LoginView(KnoxLoginView):
                             status=status.HTTP_401_UNAUTHORIZED,
                         )
 
-                    # Use pyotp for verification
+                    # Use pyotp for verification with time window
                     totp = pyotp.TOTP(totp_device.key)
-                    if not totp.verify(request.data.get("totp_code")):
+                    if not totp.verify(request.data.get("totp_code"), valid_window=1):
                         return Response(
                             {"error": "Invalid TOTP code"},
                             status=status.HTTP_401_UNAUTHORIZED,
@@ -317,6 +317,13 @@ def totp_verify(request):
                 username=temp_reg.username,
                 email=temp_reg.email,
                 password=temp_reg.password,
+            )
+
+            # Create and confirm TOTP device
+            TOTPDevice.objects.create(
+                user=user,
+                key=temp_reg.totp_secret,
+                confirmed=True
             )
 
             # Cleanup

--- a/client/src/app/components/Nav.tsx
+++ b/client/src/app/components/Nav.tsx
@@ -66,14 +66,6 @@ function NavBar() {
     }
   };
 
-  if (isLoggingOut) {
-    return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
-      </div>
-    );
-  }
-
   useEffect(() => {
     const fetchUserProfile = async () => {
       try {
@@ -83,16 +75,22 @@ function NavBar() {
 
         if (res.ok) {
           const data = await res.json();
-          setProfilePhoto(data.user.profile.profile_photo)
+          setProfilePhoto(data.user.profile.profile_photo);
         }
       } catch (error) {
         console.error("Auth check failed:", error);
-      } finally {
-        // setIsLoading(false);
       }
     };
     fetchUserProfile();
   }, []);
+
+  if (isLoggingOut) {
+    return (
+      <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+      </div>
+    );
+  }
 
   return (
     <AppBar position="fixed" sx={{ backgroundColor: "#1A1A1A" }}>


### PR DESCRIPTION
Increased time window +30 seconds before and after (so 90 seconds total) to mitigate clock sync issues between authenticator app and browser (hopefully it works)

Manually created the TOTP device so that we are asked to enter code if the user is using 2FA